### PR TITLE
arm64: dts: rockchip: enable audio output for rk3399-rg552

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rg552.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rg552.dts
@@ -231,51 +231,46 @@
 		vcc-supply = <&vcc5v0_sys>;
         };
 
-	/* FIXME */
-        es8316-sound {
-                compatible = "simple-audio-card";
-                pinctrl-names = "default";
-                pinctrl-0 = <&hp_det_pin>;
+	es8316-sound {
+		compatible = "simple-audio-card";
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det_pin>;
 		simple-audio-card,name = "rockchip,es8316-codec";
-                simple-audio-card,format = "i2s";
-                simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,format = "i2s";
+		simple-audio-card,mclk-fs = <256>;
 
-                simple-audio-card,widgets =
-                        "Microphone", "Mic Jack",
-                        "Headphone", "Headphones";
-//                        "Speaker", "Speaker";
-                simple-audio-card,routing =
-                        "MIC1", "Mic Jack",
-                        "Headphones", "HPOL",
-                        "Headphones", "HPOR";
-                        //"Speaker Amplifier INL", "HPOL",
-                        //"Speaker Amplifier INR", "HPOR",
-                        //"Speaker", "Speaker Amplifier OUTL",
-                        //"Speaker", "Speaker Amplifier OUTR";
+		simple-audio-card,widgets =
+			"Headphone", "Headphone Jack",
+			"Speaker", "Speaker";
+		simple-audio-card,routing =
+			"Headphone Jack", "HPOL",
+			"Headphone Jack", "HPOR",
+			"Speaker Amplifier INL", "HPOL",
+			"Speaker Amplifier INR", "HPOR",
+			"Speaker", "Speaker Amplifier OUTL",
+			"Speaker", "Speaker Amplifier OUTR";
 
-                simple-audio-card,hp-det-gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
-                //simple-audio-card,aux-devs = <&speaker_amp>;
-                //simple-audio-card,pin-switches = "Speaker";                   
+		simple-audio-card,hp-det-gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+		simple-audio-card,aux-devs = <&speaker_amp>;
+		simple-audio-card,pin-switches = "Speaker";
 
-                simple-audio-card,cpu {
-                        sound-dai = <&i2s1>;
-                        //system-clock-frequency = <11289600>;
-                };
+		simple-audio-card,cpu {
+			sound-dai = <&i2s1>;
+		};
 
-                simple-audio-card,codec {
-                        sound-dai = <&es8316>;
-                        //system-clock-frequency = <11289600>;
-                };
-        };
+		simple-audio-card,codec {
+			sound-dai = <&es8316>;
+		};
+	};
 
-        speaker_amp: speaker-amplifier {
-                compatible = "simple-audio-amplifier";
+	speaker_amp: speaker-amplifier {
+		compatible = "simple-audio-amplifier";
 		pinctrl-names = "default";
 		pinctrl-0 = <&spk_en_pin>;
-                enable-gpios = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
-                sound-name-prefix = "Speaker Amplifier";
-                VCC-supply = <&vcc5v0_sys>;
-        };
+		enable-gpios = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
+		sound-name-prefix = "Speaker Amplifier";
+		VCC-supply = <&vcc5v0_sys>;
+	};
 
 	fan: pwm-fan {
 		compatible = "pwm-fan";
@@ -875,22 +870,12 @@
 	i2c-scl-falling-time-ns = <15>;
 	status = "okay";
 
-	// FIXME
 	es8316: es8316@11 {
-		#sound-dai-cells = <0>;
 		compatible = "everest,es8316";
 		reg = <0x11>;
 		clocks = <&cru SCLK_I2S_8CH_OUT>;
 		clock-names = "mclk";
-
-		interrupt-parent = <&gpio0>;
-		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_HIGH>;
-		
-//		port {
-//			es8316_p0_0: endpoint {
-//				remote-endpoint = <&i2s1_p0_0>;
-//			};
-//		};
+		#sound-dai-cells = <0>;
 	};
 };
 
@@ -963,27 +948,13 @@
 	};
 };
 
-//&i2s0 {
-//	rockchip,playback-channels = <8>;
-//	rockchip,capture-channels = <8>;
-//	status = "okay";
-//};
-
 &i2s1 {
-	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2s_8ch_mclk_pin>, <&i2s1_2ch_bus>;
 	rockchip,i2s-broken-burst-len;
 	rockchip,playback-channels = <8>;
 	rockchip,capture-channels = <8>;
-//	#sound-dai-cells = <0>;
-//	i2s1_p0: port {
-//		i2s1_p0_0: endpoint {
-//			dai-format = "i2s";
-//			mclk-fs = <256>;
-//			remote-endpoint = <&es8316_p0_0>;
-//		};
-//	};
+	status = "okay";
 };
 
 &i2s2 {


### PR DESCRIPTION
Signed-off-by: Brian McKenna <brian@brianmckenna.org>

---

While reviewing this diff I realised I pretty much didn't do anything so whoever else had a go at this got close!

One thing to keep in mind is that you have to probably unmute a few things in ALSA. Make sure you've turned up the DAC volume and unmuted the left/right channels.